### PR TITLE
Update broken links - fixes #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Todo Kanban Board manages tasks and save them as [TODO.md](https://bit.ly/2JdEuE
 - Checkboxes are optional (if your task titles don't have them).
 - Task title can also have markdown for styling, hyperlinks, simple html or even img tags.
 - Task menu: to insert a sub-task, emoji icons (like bug 🐞 blocked ❌ party 🎉 etc.).
-- See also: <a href="https://bit.ly/2SfcKaH">Documentation / Guides</a>
+- See also: <a href="https://github.com/coddx-hq/coddx-alpha/blob/master/docs/documentation.md">Documentation / Guides</a>
 
 ## Usage:
 
@@ -28,7 +28,7 @@ Todo Kanban Board manages tasks and save them as [TODO.md](https://bit.ly/2JdEuE
 ## Support
 
 - For Feedbacks, Bug Reports: https://github.com/coddx-hq/coddx-alpha/issues
-- Documentation: <a href="https://bit.ly/2SfcKaH">Documentation / Guides</a>
+- Documentation: <a href="https://github.com/coddx-hq/coddx-alpha/blob/master/docs/documentation.md">Documentation / Guides</a>
 - <a href="https://bit.ly/2y4fgqh">CHANGELOG</a>
 
 ## Next milestone:

--- a/docs/task-board.md
+++ b/docs/task-board.md
@@ -10,7 +10,7 @@ Todo Kanban Board manages tasks and save them as [TODO.md](https://bit.ly/2JdEuE
 - Checkboxes are optional (if your task titles don't have them).
 - Task title can also have markdown for styling, hyperlinks, simple html or even img tags.
 - Task menu: to insert a sub-task, emoji icons (like bug 🐞 blocked ❌ party 🎉 etc.).
-- See also: <a href="https://bit.ly/2SfcKaH">Documentation / Guides</a>
+- See also: <a href="https://github.com/coddx-hq/coddx-alpha/blob/master/docs/documentation.md">Documentation / Guides</a>
 
 ## TODO.md
 

--- a/src/view/app/components/TaskBoard/ButtonBar.tsx
+++ b/src/view/app/components/TaskBoard/ButtonBar.tsx
@@ -124,7 +124,7 @@ export default ({
         </span>
         <a
           style={{ position: 'absolute', right: 15, top: 15 }}
-          href="https://nnote.cc/s/k0o93/todomd-kanban-board-documentation"
+          href="https://github.com/coddx-hq/coddx-alpha/blob/master/docs/documentation.md"
         >
           Help | Doc
         </a>


### PR DESCRIPTION
Attempted to recover broken links, but at least can point users to documentation folder